### PR TITLE
Add Three.js Earth car demo with joystick controls

### DIFF
--- a/earth-car.html
+++ b/earth-car.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Earth Car Demo</title>
+<style>
+  html,body { margin:0; height:100%; overflow:hidden; background:#000; }
+  canvas { display:block; }
+  /* joystick */
+  #joystick {
+    position:fixed; bottom:20px; left:20px; width:120px; height:120px;
+    border:1px solid #2b3b4f; border-radius:50%; background:radial-gradient(closest-side, rgba(17,197,255,.15), rgba(0,0,0,.6));
+    touch-action:none; pointer-events:auto;
+  }
+  #knob {
+    position:absolute; width:56px; height:56px; border-radius:50%; left:50%; top:50%;
+    transform:translate(-50%,-50%); background:rgba(17,197,255,.35); border:1px solid #1e2a37;
+  }
+</style>
+</head>
+<body>
+<div id="joystick"><div id="knob"></div></div>
+<script type="module">
+import * as THREE from 'https://unpkg.com/three@0.164.0/build/three.module.js';
+
+// --- constants ---
+const R = 6371000; // earth radius in meters
+const speed = 13.9; // m/s approx 50 km/h
+const turnRate = THREE.MathUtils.degToRad(45); // deg/s
+
+// --- three.js setup ---
+const renderer = new THREE.WebGLRenderer({antialias:true});
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(60, window.innerWidth/window.innerHeight, 0.1, R*4);
+
+// lights
+scene.add(new THREE.AmbientLight(0xffffff,0.8));
+const dirLight = new THREE.DirectionalLight(0xffffff,0.6);
+dirLight.position.set(1,1,1); scene.add(dirLight);
+
+// Earth
+const tex = await new THREE.TextureLoader().loadAsync('https://raw.githubusercontent.com/turban/webgl-earth/master/images/2_no_clouds_4k.jpg');
+const earthGeo = new THREE.SphereGeometry(R, 64, 64);
+const earthMat = new THREE.MeshPhongMaterial({map:tex});
+const earth = new THREE.Mesh(earthGeo, earthMat);
+scene.add(earth);
+
+// Car (simple box)
+const carGeo = new THREE.BoxGeometry(4, 1.5, 2);
+const carMat = new THREE.MeshPhongMaterial({color:0xff0000});
+const car = new THREE.Mesh(carGeo, carMat);
+scene.add(car);
+
+// spawn point at 48.137154°N, 11.576124°E (Munich)
+let lat = THREE.MathUtils.degToRad(48.137154);
+let lon = THREE.MathUtils.degToRad(11.576124);
+let heading = 0; // radians, 0=north
+
+function updateCarPosition(){
+  const x = R * Math.cos(lat) * Math.cos(lon);
+  const y = R * Math.sin(lat);
+  const z = R * Math.cos(lat) * Math.sin(lon);
+  car.position.set(x,y,z);
+  const up = new THREE.Vector3(x,y,z).normalize();
+  const east = new THREE.Vector3(0,1,0).cross(up).normalize();
+  const north = east.clone().cross(up).normalize();
+  const forward = north.clone().applyAxisAngle(up, heading);
+  car.quaternion.setFromUnitVectors(new THREE.Vector3(0,1,0), up);
+  car.rotateOnWorldAxis(up, heading);
+  camera.position.copy(car.position).add(up.clone().multiplyScalar(10)).add(forward.clone().multiplyScalar(-20));
+  camera.lookAt(car.position);
+}
+updateCarPosition();
+
+// --- joystick handling ---
+const joystick = document.getElementById('joystick');
+const knob = document.getElementById('knob');
+const joy = {x:0,y:0,active:false};
+
+joystick.addEventListener('pointerdown',e=>{joy.active=true; handle(e);});
+window.addEventListener('pointermove',e=>{if(joy.active) handle(e);});
+window.addEventListener('pointerup',()=>{joy.active=false; knob.style.transform='translate(-50%,-50%)'; joy.x=joy.y=0;});
+
+function handle(e){
+  const rect = joystick.getBoundingClientRect();
+  const x = e.clientX - rect.left - rect.width/2;
+  const y = e.clientY - rect.top - rect.height/2;
+  const max = rect.width/2;
+  const mag = Math.min(Math.hypot(x,y), max);
+  const nx = (x/mag) || 0;
+  const ny = (y/mag) || 0;
+  knob.style.transform = `translate(${nx*mag}px, ${ny*mag}px) translate(-50%,-50%)`;
+  joy.x = nx * (mag/max);
+  joy.y = ny * (mag/max);
+}
+
+// --- movement loop ---
+const clock = new THREE.Clock();
+function animate(){
+  requestAnimationFrame(animate);
+  const dt = clock.getDelta();
+  if(joy.y < -0.01){ // forward
+    const dist = speed * (-joy.y) * dt;
+    const bearing = heading;
+    const dR = dist / R;
+    const sinLat = Math.sin(lat), cosLat = Math.cos(lat);
+    const sinDR = Math.sin(dR), cosDR = Math.cos(dR);
+    const sinLat2 = sinLat*cosDR + cosLat*sinDR*Math.cos(bearing);
+    const lat2 = Math.asin(sinLat2);
+    const y = Math.sin(bearing)*sinDR*cosLat;
+    const x = cosDR - sinLat*sinLat2;
+    const lon2 = lon + Math.atan2(y, x);
+    lat = lat2; lon = lon2;
+  }
+  if(Math.abs(joy.x)>0.01){
+    heading -= joy.x * turnRate * dt;
+  }
+  updateCarPosition();
+  renderer.render(scene,camera);
+}
+animate();
+
+window.addEventListener('resize',()=>{
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  camera.aspect = window.innerWidth/window.innerHeight;
+  camera.updateProjectionMatrix();
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add standalone demo rendering a textured Earth with Three.js
- Spawn a simple car on the globe and keep it pinned to the surface while driving
- Provide on-screen joystick for forward/steering input and follow camera

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb308272bc8327bf497869956ab17c