### PR TITLE
Improve pointer locking for initial gameplay

### DIFF
--- a/main.js
+++ b/main.js
@@ -56,6 +56,7 @@ topBtn.addEventListener('click',()=>{toggleTopView(true);});
 returnTopBtn.addEventListener('click',()=>{toggleTopView(false);});
 
 function showMenu(){
+  if(controls) controls.unlock();
   cancelAnimationFrame(animationId);
   clearInterval(timerInterval);
   gameScreen.classList.add('hidden');
@@ -94,6 +95,8 @@ function startGame(diff){
 
   controls=new PointerLockControls(camera, renderer.domElement);
   renderer.domElement.addEventListener('click',()=>controls.lock());
+  // Lock pointer immediately after starting so the game is ready to play
+  controls.lock();
 
   buildMaze();
   placeGoal();


### PR DESCRIPTION
## Summary
- Automatically lock the pointer when a game starts
- Release pointer lock when returning to the menu

## Testing
- `node --check main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6b4dfdd0832788fefcc09eca260c